### PR TITLE
Fix config path resolution and improve CLI error messages

### DIFF
--- a/RackPeek/Program.cs
+++ b/RackPeek/Program.cs
@@ -11,7 +11,7 @@ public static class Program
     public static async Task<int> Main(string[] args)
     {
         // Configuration
-        var configuration = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory())
+        var configuration = new ConfigurationBuilder().SetBasePath(AppContext.BaseDirectory)
             .AddJsonFile("appsettings.json", optional: true)
             .Build();
 
@@ -28,6 +28,7 @@ public static class Program
         var app = new CommandApp(registrar);
 
         CliBootstrap.BuildApp(app);
+        CliBootstrap.SetContext(args, app);
 
         return await app.RunAsync(args);
     }


### PR DESCRIPTION
## Summary
- Resolve config directory relative to binary location (`AppContext.BaseDirectory`) instead of current working directory, allowing `rpk` to run from any directory
- Fix `YamlResourceCollection` using unresolved relative `yamlDir` instead of resolved absolute `yamlPath`
- Display contextual `--help` output when users enter invalid commands or argument types, instead of raw stack traces

Fixes #116

## Test plan
- [ ] Install `rpk` to `/usr/local/bin/` and verify it runs from any directory
- [ ] Run `rpk servers blah` and verify contextual help is shown
- [ ] Run `rpk servers drive add <name> --size 999999999999` and verify friendly error with help