### PR TITLE
Add Microsoft.Extensions.Configuration.EnvironmentVariables and use it for cli

### DIFF
--- a/RackPeek/Program.cs
+++ b/RackPeek/Program.cs
@@ -15,6 +15,7 @@ public static class Program
 
         var configuration = new ConfigurationBuilder()
             .SetBasePath(appBasePath)
+            .AddEnvironmentVariables()
             .AddJsonFile("appsettings.json", optional: true)
             .Build();
 

--- a/RackPeek/RackPeek.csproj
+++ b/RackPeek/RackPeek.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.2"/>


### PR DESCRIPTION
This fix the env variable usage for https://github.com/Timmoth/RackPeek/pull/112.

```bash
$ RPK_YAML_DIR=/tmp/rackpeek/config ./artifacts/RackPeek servers add test
Server 'test' added.

$ cat /tmp/rackpeek/config/config.yaml 
resources:
- kind: Server
  name: test
```