### PR TITLE
Added tests for schema migration

### DIFF
--- a/Tests/Yaml/SchemaMigrationTests.cs
+++ b/Tests/Yaml/SchemaMigrationTests.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using RackPeek.Domain.Persistence.Yaml;
+using RackPeek.Domain.Resources.UpsUnits;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using YamlDotNet.Core;
+
+namespace Tests.Yaml;
+
+public class SchemaMigrationTests
+{
+    private static RackPeekConfigMigrationDeserializer Setup()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var provider = services.BuildServiceProvider();
+
+        return new RackPeekConfigMigrationDeserializer(
+            provider,
+            provider.GetRequiredService<ILogger<RackPeekConfigMigrationDeserializer>>());
+    }
+
+
+    [Fact]
+    public async Task Migrations_ensures_version_exists()
+    {
+        // Arrange
+        var sut = Setup();
+
+        var yaml = """
+                   resources:
+                   - kind: Ups
+                     name: example-ups
+                   """;
+
+        // Act
+        var result = await sut.Deserialize(yaml);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(RackPeekConfigMigrationDeserializer.ListOfMigrations.Count, result.Version);
+    }
+
+    [Fact]
+    public async Task Migrations_converts_runs_on_to_list()
+    {
+        // Arrange
+        var sut = Setup();
+
+        var yaml = """
+                   version: 1
+                   resources:
+                   - kind: Ups
+                     name: example-ups
+                     runsOn: rack-a1
+                   """;
+
+        // Act
+        var result = await sut.Deserialize(yaml);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Resources);
+        var ups = Assert.IsType<Ups>(result.Resources[0]);
+        Assert.Equal(ups.RunsOn, ["rack-a1"]);
+    }
+
+    [Fact]
+    public async Task Test3()
+    {
+        // Arrange
+        var sut = Setup();
+
+        var yaml = """
+                   version: 1
+                   resources:
+                   - kind: Ups
+                     name: example-ups
+                     runsOn: 
+                        - name: rack-a1
+                          location: test
+                        - name: rack-a2
+                          location: somewhere else
+                   """;
+
+        // Act
+        var result = await sut.Deserialize(yaml);
+
+
+    }
+}

--- a/Tests/Yaml/SchemaMigrationTests.cs
+++ b/Tests/Yaml/SchemaMigrationTests.cs
@@ -2,10 +2,6 @@
 using Microsoft.Extensions.Logging;
 using RackPeek.Domain.Persistence.Yaml;
 using RackPeek.Domain.Resources.UpsUnits;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using YamlDotNet.Core;
 
 namespace Tests.Yaml;
 
@@ -66,29 +62,5 @@ public class SchemaMigrationTests
         Assert.NotNull(result.Resources);
         var ups = Assert.IsType<Ups>(result.Resources[0]);
         Assert.Equal(ups.RunsOn, ["rack-a1"]);
-    }
-
-    [Fact]
-    public async Task Test3()
-    {
-        // Arrange
-        var sut = Setup();
-
-        var yaml = """
-                   version: 1
-                   resources:
-                   - kind: Ups
-                     name: example-ups
-                     runsOn: 
-                        - name: rack-a1
-                          location: test
-                        - name: rack-a2
-                          location: somewhere else
-                   """;
-
-        // Act
-        var result = await sut.Deserialize(yaml);
-
-
     }
 }


### PR DESCRIPTION
Tests for issue #179. There's a bit of a question about whether or not the `List<object>` case in the `ConvertScalarRunsOnToList` is really valid also as I think the yaml would fail validation prior to this right?