### PR TITLE
Fixed bad links in resource-levels doc page

### DIFF
--- a/Shared.Rcl/wwwroot/raw_docs/resource-levels.md
+++ b/Shared.Rcl/wwwroot/raw_docs/resource-levels.md
@@ -92,7 +92,7 @@ Every system has a `runs-on` property that defines where it lives. A system can 
 - **Another system** — a VM running on a hypervisor, or a container running inside a VM.
 
 > [!TIP]
-> You can nest systems. A hypervisor is a system that runs on hardware, and a VM is a system that runs on that hypervisor. There is no artificial limit to how deep you can nest. See [Systems Running on Systems](#systems-running-on-systems) for a full worked example.
+> You can nest systems. A hypervisor is a system that runs on hardware, and a VM is a system that runs on that hypervisor. There is no artificial limit to how deep you can nest. See [Systems Running on Systems](docs/resource-levels#systems-running-on-systems) for a full worked example.
 
 ### Adding Systems
 
@@ -309,5 +309,5 @@ If you are unsure whether something should be hardware, a system, or a service, 
 
 ## Related Pages
 
-- [CLI Commands](cli-commands) for the full command reference
-- [Installation Guide](install-guide) to get started with RackPeek
+- [CLI Commands](docs/cli-commands) for the full command reference
+- [Installation Guide](docs/install-guide) to get started with RackPeek


### PR DESCRIPTION
## Summary

Fixes broken internal links in the resource-levels documentation page. The links were using incorrect paths and would not resolve correctly when viewing the docs (e.g. on GitHub Pages or in the Web UI).

## Changes

- **resource-levels.md**
  - Fixed anchor link to "Systems Running on Systems" section: `#systems-running-on-systems` → `docs/resource-levels#systems-running-on-systems`
  - Fixed "Related Pages" links: `cli-commands` and `install-guide` → `docs/cli-commands` and `docs/install-guide`

## How to test

1. Open the resource-levels doc page in the Web UI or the generated docs site.
2. Click the "Systems Running on Systems" link in the TIP box — it should scroll to the correct section.
3. Click the "CLI Commands" and "Installation Guide" links in the Related Pages section — they should navigate to the correct pages.

## Notes for reviewers

Single-file doc fix. No code changes.



<img width="805" height="197" alt="Selection_092" src="https://github.com/user-attachments/assets/21b39704-c625-44f5-97bc-071e7b24945d" />
<img width="640" height="190" alt="Selection_091" src="https://github.com/user-attachments/assets/3707aeac-11ca-47a8-a681-59b9e76e50eb" />
<img width="598" height="177" alt="Selection_090" src="https://github.com/user-attachments/assets/9e9e148b-904f-4a13-8a64-4a00f4a73824" />
