### PR TITLE
fix(cli): Handle quoted arguments with spaces in interactive console …

### DIFF
--- a/Shared.Rcl/ConsoleRunner.cs
+++ b/Shared.Rcl/ConsoleRunner.cs
@@ -24,9 +24,50 @@ public class ConsoleEmulator : IConsoleEmulator
         AnsiConsole.Console = testConsole;
         App.Configure(c => c.Settings.Console = testConsole);
 
-        await App.RunAsync(input.Split(" ", StringSplitOptions.RemoveEmptyEntries));
+        await App.RunAsync(ParseArguments(input));
 
         return testConsole.Output;
+    }
+
+    internal static string[] ParseArguments(string input)
+    {
+        var args = new List<string>();
+        var current = new System.Text.StringBuilder();
+        char? quote = null;
+
+        for (var i = 0; i < input.Length; i++)
+        {
+            var c = input[i];
+
+            if (quote.HasValue)
+            {
+                if (c == quote.Value)
+                    quote = null;
+                else
+                    current.Append(c);
+            }
+            else if (c is '"' or '\'')
+            {
+                quote = c;
+            }
+            else if (c == ' ')
+            {
+                if (current.Length > 0)
+                {
+                    args.Add(current.ToString());
+                    current.Clear();
+                }
+            }
+            else
+            {
+                current.Append(c);
+            }
+        }
+
+        if (current.Length > 0)
+            args.Add(current.ToString());
+
+        return args.ToArray();
     }
 }
 


### PR DESCRIPTION
…(#234)

The ConsoleEmulator.Execute() method previously split user input naively on spaces using string.Split(), which caused resource names containing spaces (e.g. "It Tools") to be incorrectly parsed as multiple separate arguments — even when wrapped in single or double quotes.

This resulted in errors like:
  "Could not match 'Tools'' with an argument."

Replace the naive split with a quote-aware ParseArguments() method that correctly handles both single-quoted ('It Tools') and double-quoted ("It Tools") strings, preserving their content as a single argument token.

Closes #234