### PR TITLE
Fix: Server type missing Model property

### DIFF
--- a/RackPeek.Domain/Resources/AccessPoints/AccessPoint.cs
+++ b/RackPeek.Domain/Resources/AccessPoints/AccessPoint.cs
@@ -2,6 +2,5 @@ namespace RackPeek.Domain.Resources.AccessPoints;
 
 public class AccessPoint : Hardware.Hardware {
     public const string KindLabel = "AccessPoint";
-    public string? Model { get; set; }
     public double? Speed { get; set; }
 }

--- a/RackPeek.Domain/Resources/Desktops/Desktop.cs
+++ b/RackPeek.Domain/Resources/Desktops/Desktop.cs
@@ -6,7 +6,6 @@ namespace RackPeek.Domain.Resources.Desktops;
 public class Desktop : Hardware.Hardware, ICpuResource, IDriveResource, IGpuResource, INicResource {
     public const string KindLabel = "Desktop";
     public Ram? Ram { get; set; }
-    public string? Model { get; set; }
     public List<Cpu>? Cpus { get; set; }
     public List<Drive>? Drives { get; set; }
     public List<Gpu>? Gpus { get; set; }

--- a/RackPeek.Domain/Resources/Firewalls/Firewall.cs
+++ b/RackPeek.Domain/Resources/Firewalls/Firewall.cs
@@ -5,7 +5,6 @@ namespace RackPeek.Domain.Resources.Firewalls;
 
 public class Firewall : Hardware.Hardware, IPortResource {
     public const string KindLabel = "Firewall";
-    public string? Model { get; set; }
     public bool? Managed { get; set; }
     public bool? Poe { get; set; }
     public List<Port>? Ports { get; set; }

--- a/RackPeek.Domain/Resources/Hardware/Hardware.cs
+++ b/RackPeek.Domain/Resources/Hardware/Hardware.cs
@@ -1,4 +1,11 @@
 namespace RackPeek.Domain.Resources.Hardware;
 
+/// <summary>
+/// Base class for all physical hardware resources.
+/// </summary>
 public abstract class Hardware : Resource {
+    /// <summary>
+    /// The hardware model identifier (e.g. "Dell PowerEdge R730", "Arista DCS-7050TX-64-R").
+    /// </summary>
+    public string? Model { get; set; }
 }

--- a/RackPeek.Domain/Resources/Laptops/Laptop.cs
+++ b/RackPeek.Domain/Resources/Laptops/Laptop.cs
@@ -6,7 +6,6 @@ namespace RackPeek.Domain.Resources.Laptops;
 public class Laptop : Hardware.Hardware, ICpuResource, IDriveResource, IGpuResource {
     public const string KindLabel = "Laptop";
     public Ram? Ram { get; set; }
-    public string? Model { get; set; }
     public List<Cpu>? Cpus { get; set; }
     public List<Drive>? Drives { get; set; }
     public List<Gpu>? Gpus { get; set; }

--- a/RackPeek.Domain/Resources/Routers/Router.cs
+++ b/RackPeek.Domain/Resources/Routers/Router.cs
@@ -5,7 +5,6 @@ namespace RackPeek.Domain.Resources.Routers;
 
 public class Router : Hardware.Hardware, IPortResource {
     public const string KindLabel = "Router";
-    public string? Model { get; set; }
     public bool? Managed { get; set; }
     public bool? Poe { get; set; }
     public List<Port>? Ports { get; set; }

--- a/RackPeek.Domain/Resources/Servers/DescribeServerUseCase.cs
+++ b/RackPeek.Domain/Resources/Servers/DescribeServerUseCase.cs
@@ -5,6 +5,7 @@ namespace RackPeek.Domain.Resources.Servers;
 
 public record ServerDescription(
     string Name,
+    string? Model,
     string CpuSummary,
     int TotalCores,
     int TotalThreads,
@@ -32,6 +33,7 @@ public class DescribeServerUseCase(IResourceCollection repository) : IUseCase {
 
         return new ServerDescription(
             server.Name,
+            server.Model,
             cpuSummary,
             server.Cpus?.Sum(c => c.Cores) ?? 0,
             server.Cpus?.Sum(c => c.Threads) ?? 0,

--- a/RackPeek.Domain/Resources/Servers/ServerHardwareReport.cs
+++ b/RackPeek.Domain/Resources/Servers/ServerHardwareReport.cs
@@ -9,6 +9,7 @@ public record ServerHardwareReport(
 
 public record ServerHardwareRow(
     string Name,
+    string? Model,
     string CpuSummary,
     int TotalCores,
     int TotalThreads,
@@ -82,6 +83,7 @@ public class ServerHardwareReportUseCase(IResourceCollection repository) : IUseC
 
             return new ServerHardwareRow(
                 server.Name,
+                server.Model,
                 cpuSummary,
                 totalCores,
                 totalThreads,

--- a/RackPeek.Domain/Resources/Servers/UpdateServerUseCase.cs
+++ b/RackPeek.Domain/Resources/Servers/UpdateServerUseCase.cs
@@ -10,17 +10,19 @@ public class UpdateServerUseCase(IResourceCollection repository) : IUseCase {
         double? ramGb = null,
         int? ramMts = null,
         bool? ipmi = null,
-        string? notes = null
+        string? notes = null,
+        string? model = null
     ) {
-        // ToDo pass in properties as inputs, construct the entity in the usecase, ensure optional inputs are nullable
-        // ToDo validate / normalize all inputs
-
         name = Normalize.HardwareName(name);
         ThrowIfInvalid.ResourceName(name);
 
         var server = await repository.GetByNameAsync(name) as Server;
         if (server == null)
             throw new NotFoundException($"Server '{name}' not found.");
+
+        // ---- Model ----
+        if (!string.IsNullOrWhiteSpace(model))
+            server.Model = model;
 
         // ---- RAM ----
         if (ramGb.HasValue) {

--- a/RackPeek.Domain/Resources/Switches/Switch.cs
+++ b/RackPeek.Domain/Resources/Switches/Switch.cs
@@ -5,7 +5,6 @@ namespace RackPeek.Domain.Resources.Switches;
 
 public class Switch : Hardware.Hardware, IPortResource {
     public const string KindLabel = "Switch";
-    public string? Model { get; set; }
     public bool? Managed { get; set; }
     public bool? Poe { get; set; }
     public List<Port>? Ports { get; set; }

--- a/RackPeek.Domain/Resources/UpsUnits/Ups.cs
+++ b/RackPeek.Domain/Resources/UpsUnits/Ups.cs
@@ -2,6 +2,5 @@ namespace RackPeek.Domain.Resources.UpsUnits;
 
 public class Ups : Hardware.Hardware {
     public const string KindLabel = "Ups";
-    public string? Model { get; set; }
     public int? Va { get; set; }
 }

--- a/Shared.Rcl/Commands/Servers/ServerDescribeCommand.cs
+++ b/Shared.Rcl/Commands/Servers/ServerDescribeCommand.cs
@@ -25,6 +25,7 @@ public class ServerDescribeCommand(
             .AddColumn();
 
         grid.AddRow("Name", server.Name);
+        grid.AddRow("Model", server.Model ?? "Unknown");
         grid.AddRow("IPMI", server.Ipmi == true ? "yes" : "no");
         grid.AddRow("RAM", $"{server.Ram?.Size ?? 0} GB");
 

--- a/Shared.Rcl/Commands/Servers/ServerGetByNameCommand.cs
+++ b/Shared.Rcl/Commands/Servers/ServerGetByNameCommand.cs
@@ -20,7 +20,7 @@ public class ServerGetByNameCommand(
         Server server = await useCase.ExecuteAsync(settings.Name);
 
         AnsiConsole.MarkupLine(
-            $"[green]{server.Name}[/]  RAM: {server.Ram?.Size} GB, IPMI: {(server.Ipmi == true ? "yes" : "no")}");
+            $"[green]{server.Name}[/]  Model: {server.Model ?? "Unknown"}, RAM: {server.Ram?.Size} GB, IPMI: {(server.Ipmi == true ? "yes" : "no")}");
 
         return 0;
     }

--- a/Shared.Rcl/Commands/Servers/ServerGetCommand.cs
+++ b/Shared.Rcl/Commands/Servers/ServerGetCommand.cs
@@ -24,6 +24,7 @@ public class ServerGetCommand(
         Table table = new Table()
             .Border(TableBorder.Rounded)
             .AddColumn("Name")
+            .AddColumn("Model")
             .AddColumn("CPU")
             .AddColumn("C/T")
             .AddColumn("RAM")
@@ -34,6 +35,7 @@ public class ServerGetCommand(
         foreach (ServerHardwareRow s in report.Servers)
             table.AddRow(
                 s.Name,
+                s.Model ?? "Unknown",
                 s.CpuSummary,
                 $"{s.TotalCores}/{s.TotalThreads}",
                 $"{s.RamGb} GB",

--- a/Shared.Rcl/Commands/Servers/ServerSetCommand.cs
+++ b/Shared.Rcl/Commands/Servers/ServerSetCommand.cs
@@ -6,6 +6,7 @@ using Spectre.Console.Cli;
 namespace Shared.Rcl.Commands.Servers;
 
 public class ServerSetSettings : ServerNameSettings {
+    [CommandOption("--Model")] public string? Model { get; set; }
     [CommandOption("--ram <GB>")] public int RamGb { get; set; }
     [CommandOption("--ram_mts <MTs>")] public int RamMts { get; set; }
 
@@ -26,7 +27,8 @@ public class ServerSetCommand(
             settings.Name,
             settings.RamGb,
             settings.RamMts,
-            settings.Ipmi);
+            settings.Ipmi,
+            model: settings.Model);
 
         AnsiConsole.MarkupLine($"[green]Server '{settings.Name}' updated.[/]");
         return 0;

--- a/Shared.Rcl/Servers/ServerCardComponent.razor
+++ b/Shared.Rcl/Servers/ServerCardComponent.razor
@@ -71,6 +71,48 @@
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
 
+        <!-- Model -->
+        <div data-testid="server-model-section">
+            <div class="text-zinc-400 mb-1">Model</div>
+
+            @if (_editingModel)
+            {
+                <div class="flex gap-2">
+                    <input data-testid="server-model-input"
+                           class="w-full px-3 py-2 rounded-md bg-zinc-800 text-zinc-100 border border-zinc-600"
+                           @bind="_modelDraft"/>
+                    <button data-testid="save-model-button"
+                            class="text-xs text-emerald-400 hover:text-emerald-300"
+                            @onclick="SaveModel">
+                        Save
+                    </button>
+                    <button data-testid="cancel-model-button"
+                            class="text-xs text-zinc-500 hover:text-zinc-300"
+                            @onclick="CancelModelEdit">
+                        Cancel
+                    </button>
+                </div>
+            }
+            else if (!string.IsNullOrWhiteSpace(Server.Model))
+            {
+                <div class="flex items-center gap-2 text-zinc-300 group hover:bg-zinc-800/40 rounded px-1 py-0.5">
+                    <button data-testid="edit-model-button"
+                            class="hover:text-emerald-400"
+                            @onclick="BeginModelEdit">
+                        @Server.Model
+                    </button>
+                </div>
+            }
+            else
+            {
+                <button data-testid="add-model-button"
+                        class="text-xs text-zinc-500 hover:text-emerald-400"
+                        @onclick="BeginModelEdit">
+                    + Add model
+                </button>
+            }
+        </div>
+
         <div data-testid="server-cpu-section">
             <div class="flex items-center justify-between mb-1 group">
                 <div class="text-zinc-400">CPU
@@ -339,6 +381,33 @@
 
 @code {
     [Parameter] [EditorRequired] public Server Server { get; set; } = default!;
+
+    #region Model
+
+    bool _editingModel;
+    string? _modelDraft;
+
+    void BeginModelEdit()
+    {
+        _editingModel = true;
+        _modelDraft = Server.Model;
+    }
+
+    void CancelModelEdit()
+    {
+        _editingModel = false;
+        _modelDraft = null;
+    }
+
+    async Task SaveModel()
+    {
+        _editingModel = false;
+        await UpdateUseCase.ExecuteAsync(Server.Name, model: _modelDraft);
+        Server = await GetByNameUseCase.ExecuteAsync(Server.Name);
+        _modelDraft = null;
+    }
+
+    #endregion
 
     #region RAM
 

--- a/schemas/v2/schema.v2.json
+++ b/schemas/v2/schema.v2.json
@@ -153,6 +153,7 @@
           "properties": {
             "kind": { "const": "Server" },
 
+            "model": { "type": "string" },
             "ram": { "$ref": "#/$defs/ram" },
             "ipmi": { "type": "boolean" },
             "cpus": { "type": "array", "items": { "$ref": "#/$defs/cpu" } },
@@ -173,6 +174,7 @@
           "properties": {
             "kind": { "const": "Desktop" },
 
+            "model": { "type": "string" },
             "ram": { "$ref": "#/$defs/ram" },
             "cpus": { "type": "array", "items": { "$ref": "#/$defs/cpu" } },
             "drives": { "type": "array", "items": { "$ref": "#/$defs/drive" } },
@@ -192,6 +194,7 @@
           "properties": {
             "kind": { "const": "Laptop" },
 
+            "model": { "type": "string" },
             "ram": { "$ref": "#/$defs/ram" },
             "cpus": { "type": "array", "items": { "$ref": "#/$defs/cpu" } },
             "drives": { "type": "array", "items": { "$ref": "#/$defs/drive" } }


### PR DESCRIPTION
## Summary

Fixes #239

The `Server` resource type was the **only** hardware type missing a `Model` property. This caused YAML deserialization to fail when users included `model:` on a Server resource:

```
Property 'model' not found on type 'RackPeek.Domain.Resources.Servers.Server'
```

## Changes

### Domain layer
- **`Hardware.cs`** — Added `Model` to the abstract base class (consolidates from 7 subclasses)
- **`Firewall.cs`**, **`Switch.cs`**, **`Router.cs`**, **`AccessPoint.cs`**, **`Ups.cs`**, **`Desktop.cs`**, **`Laptop.cs`** — Removed duplicate `Model` declaration (now inherited)
- **`UpdateServerUseCase.cs`** — Added `model` parameter
- **`DescribeServerUseCase.cs`** — Added `Model` to `ServerDescription` record
- **`ServerHardwareReport.cs`** — Added `Model` to `ServerHardwareRow` record

### Web UI
- **`ServerCardComponent.razor`** — Added Model display/edit section with click-to-edit pattern

### CLI
- **`ServerSetCommand.cs`** — Added `--Model` CLI option
- **`ServerDescribeCommand.cs`** — Shows Model in describe output
- **`ServerGetByNameCommand.cs`** — Shows Model in single-server output
- **`ServerGetCommand.cs`** — Added Model column to server list table

### Schema
- **`schema.v2.json`** — Added `model` to `server`, `desktop`, and `laptop` definitions (were missing despite C# classes supporting it)

## Notes

- No YAML migration needed — `model` is nullable/optional, so existing configs without it continue to work
- `RackPeek.Domain` and `Shared.Rcl` build cleanly (0 warnings, 0 errors)
- Could not run full test suite locally (missing ASP.NET targeting pack on Arch Linux) — CI should validate

## Related

- #223 requests expanding Server fields broadly; this PR addresses the specific inconsistency where `model` was missing from Server while present on all other hardware types