### PR TITLE
Feature/global search

### DIFF
--- a/Shared.Rcl/Components/GlobalSearch.razor
+++ b/Shared.Rcl/Components/GlobalSearch.razor
@@ -1,6 +1,7 @@
 @* Global resource search — header-level palette.
 
    Keyboard:  ↑/↓ move the highlight, Enter navigates, Esc clears.
+   Blur:      Clicking anywhere outside the input closes the dropdown.
 *@
 
 @using Microsoft.AspNetCore.Components.Web
@@ -23,7 +24,8 @@
            @bind="_query"
            @bind:event="oninput"
            @bind:after="RunSearchAsync"
-           @onkeydown="OnKeyDown"/>
+           @onkeydown="OnKeyDown"
+           @onfocusout="OnFocusOut"/>
 
     @if (!string.IsNullOrWhiteSpace(_query))
     {
@@ -67,15 +69,23 @@
 </div>
 
 @code {
+    // Brief delay on focus-out so a click on a result button can fire first.
+    // Browser event order is mousedown → blur → click, so the focus-out fires
+    // before the click handler on the button. The delay lets the click register
+    // before we close the dropdown.
+    private const int _blurCloseDelayMs = 150;
+
     private string _query = string.Empty;
     private IReadOnlyList<SearchResult> _results = [];
-    private IReadOnlyList<Resource>? _resources;
     private int _highlightedIndex;
 
     private async Task RunSearchAsync()
     {
-        _resources ??= await Repo.GetAllOfTypeAsync<Resource>();
-        _results = GlobalSearchService.Search(_resources, _query);
+        // Reload every search so newly added / edited / deleted resources show up
+        // without a hard page refresh. The repo layer is already in-memory, so
+        // this is a cheap dictionary lookup, not a disk read.
+        var resources = await Repo.GetAllOfTypeAsync<Resource>();
+        _results = GlobalSearchService.Search(resources, _query);
         _highlightedIndex = 0;
     }
 
@@ -99,19 +109,32 @@
                 break;
 
             case "Escape":
-                _query = string.Empty;
-                _results = [];
-                _highlightedIndex = 0;
+                Close();
                 break;
+        }
+    }
+
+    private async Task OnFocusOut()
+    {
+        await Task.Delay(_blurCloseDelayMs);
+        if (!string.IsNullOrEmpty(_query))
+        {
+            Close();
+            StateHasChanged();
         }
     }
 
     private void OnResultSelected(SearchResult r)
     {
+        Close();
+        Nav.NavigateTo(r.Url);
+    }
+
+    private void Close()
+    {
         _query = string.Empty;
         _results = [];
         _highlightedIndex = 0;
-        Nav.NavigateTo(r.Url);
     }
 
     private static string Sanitize(string value) =>

--- a/Shared.Rcl/Components/GlobalSearch.razor
+++ b/Shared.Rcl/Components/GlobalSearch.razor
@@ -1,0 +1,119 @@
+@* Global resource search — header-level palette.
+
+   Keyboard:  ↑/↓ move the highlight, Enter navigates, Esc clears.
+*@
+
+@using Microsoft.AspNetCore.Components.Web
+@using RackPeek.Domain.Persistence
+@using RackPeek.Domain.Resources
+@using Shared.Rcl.Services
+
+@inject IResourceCollection Repo
+@inject NavigationManager Nav
+
+<div class="relative">
+    <input type="search"
+           data-testid="global-search-input"
+           placeholder="Search resources…"
+           autocomplete="off"
+           class="bg-zinc-800 text-zinc-200 placeholder-zinc-500
+                  border border-zinc-700 rounded
+                  px-3 py-1 text-sm w-72
+                  focus:outline-none focus:border-emerald-400"
+           @bind="_query"
+           @bind:event="oninput"
+           @bind:after="RunSearchAsync"
+           @onkeydown="OnKeyDown"/>
+
+    @if (!string.IsNullOrWhiteSpace(_query))
+    {
+        <div data-testid="global-search-results"
+             class="absolute left-0 right-0 mt-1 z-50
+                    bg-zinc-900 border border-zinc-700 rounded
+                    shadow-lg max-h-96 overflow-y-auto text-sm">
+
+            @if (_results.Count == 0)
+            {
+                <div data-testid="global-search-no-results"
+                     class="px-3 py-2 text-zinc-500 italic">
+                    No matches.
+                </div>
+            }
+            else
+            {
+                @for (var i = 0; i < _results.Count; i++)
+                {
+                    var r = _results[i];
+                    var highlighted = i == _highlightedIndex;
+                    var rowClass = highlighted
+                        ? "bg-zinc-800 border-l-2 border-emerald-400"
+                        : "hover:bg-zinc-800 border-l-2 border-transparent";
+
+                    <button type="button"
+                            data-testid="@($"global-search-result-{Sanitize(r.Kind)}-{Sanitize(r.Name)}")"
+                            @onclick="() => OnResultSelected(r)"
+                            class="@($"w-full text-left block px-3 py-2 text-zinc-200 border-b border-zinc-800 last:border-b-0 cursor-pointer {rowClass}")">
+
+                        <div class="font-medium text-emerald-400">@r.Name</div>
+                        <div data-testid="global-search-result-match"
+                             class="text-xs text-zinc-500">
+                            @r.Kind · via @r.MatchedField: @r.MatchedValue
+                        </div>
+                    </button>
+                }
+            }
+        </div>
+    }
+</div>
+
+@code {
+    private string _query = string.Empty;
+    private IReadOnlyList<SearchResult> _results = [];
+    private IReadOnlyList<Resource>? _resources;
+    private int _highlightedIndex;
+
+    private async Task RunSearchAsync()
+    {
+        _resources ??= await Repo.GetAllOfTypeAsync<Resource>();
+        _results = GlobalSearchService.Search(_resources, _query);
+        _highlightedIndex = 0;
+    }
+
+    private void OnKeyDown(KeyboardEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case "ArrowDown":
+                if (_results.Count > 0)
+                    _highlightedIndex = Math.Min(_highlightedIndex + 1, _results.Count - 1);
+                break;
+
+            case "ArrowUp":
+                if (_results.Count > 0)
+                    _highlightedIndex = Math.Max(_highlightedIndex - 1, 0);
+                break;
+
+            case "Enter":
+                if (_highlightedIndex >= 0 && _highlightedIndex < _results.Count)
+                    OnResultSelected(_results[_highlightedIndex]);
+                break;
+
+            case "Escape":
+                _query = string.Empty;
+                _results = [];
+                _highlightedIndex = 0;
+                break;
+        }
+    }
+
+    private void OnResultSelected(SearchResult r)
+    {
+        _query = string.Empty;
+        _results = [];
+        _highlightedIndex = 0;
+        Nav.NavigateTo(r.Url);
+    }
+
+    private static string Sanitize(string value) =>
+        value.Replace(" ", "-").ToLowerInvariant();
+}

--- a/Shared.Rcl/Layout/MainLayout.razor
+++ b/Shared.Rcl/Layout/MainLayout.razor
@@ -1,30 +1,35 @@
 ﻿@using RackPeek.Domain
+@using Shared.Rcl.Components
 @inherits LayoutComponentBase
 <div class="min-h-screen bg-zinc-950 text-zinc-200 font-mono"
      data-testid="app-root">
 
     <header class="flex items-center justify-between p-4 border-b border-zinc-800 bg-zinc-900"
             data-testid="app-header">
-        <NavLink href=""
-                 data-testid="brand-link"
-                 class="hover:text-emerald-400"
-                 activeClass="text-emerald-400 font-semibold">
+        <div class="flex items-center gap-6">
+            <NavLink href=""
+                     data-testid="brand-link"
+                     class="hover:text-emerald-400"
+                     activeClass="text-emerald-400 font-semibold">
 
-            <div class="flex items-center gap-3"
-                 data-testid="brand-text">
+                <div class="flex items-center gap-3"
+                     data-testid="brand-text">
 
-                <span class="text-xl font-bold text-emerald-400 tracking-wider">
-                    rackpeek
-                </span>
+                    <span class="text-xl font-bold text-emerald-400 tracking-wider">
+                        rackpeek
+                    </span>
 
-                <span class="text-[10px]
-                     text-zinc-500
-                     tracking-wide">
-                    @RpkConstants.Version
-                </span>
+                    <span class="text-[10px]
+                         text-zinc-500
+                         tracking-wide">
+                        @RpkConstants.Version
+                    </span>
 
-            </div>
-        </NavLink>
+                </div>
+            </NavLink>
+
+            <GlobalSearch/>
+        </div>
 
         <div class="flex items-center gap-6">
             @if (RpkConstants.HasGitServices)

--- a/Shared.Rcl/Services/GlobalSearchService.cs
+++ b/Shared.Rcl/Services/GlobalSearchService.cs
@@ -1,0 +1,119 @@
+using RackPeek.Domain.Resources;
+using RackPeek.Domain.Resources.Services;
+using RackPeek.Domain.Resources.SystemResources;
+
+namespace Shared.Rcl.Services;
+
+public record SearchResult(
+    string Name,
+    string Kind,
+    string Url,
+    string MatchedField,
+    string MatchedValue,
+    int Score
+);
+
+/// <summary>
+/// Ranks a set of resources against a free-text query and returns the top N matches.
+///
+/// Scoring per resource: each searchable field is scored independently with a
+/// weight (name &gt; ip &gt; tag &gt; label) and a shape modifier (equality &gt;
+/// prefix &gt; substring &gt; subsequence). The resource takes the best-scoring
+/// single field, so a strong name match always beats a weak label match.
+/// </summary>
+public static class GlobalSearchService {
+    private const int _defaultMax = 8;
+
+    private const int _weightName = 100;
+    private const int _weightIp = 50;
+    private const int _weightTag = 25;
+    private const int _weightLabel = 10;
+
+    public static IReadOnlyList<SearchResult> Search(
+        IEnumerable<Resource> resources,
+        string query,
+        int max = _defaultMax) {
+        if (string.IsNullOrWhiteSpace(query)) return [];
+
+        var q = query.Trim().ToLowerInvariant();
+        var results = new List<SearchResult>();
+
+        foreach (Resource r in resources) {
+            (string Field, string Value, int Score)? best = BestMatch(r, q);
+            if (best is null) continue;
+
+            results.Add(new SearchResult(
+                Name: r.Name,
+                Kind: r.Kind,
+                Url: Resource.GetResourceUrl(r.Kind, r.Name),
+                MatchedField: best.Value.Field,
+                MatchedValue: best.Value.Value,
+                Score: best.Value.Score));
+        }
+
+        return results
+            .OrderByDescending(s => s.Score)
+            .ThenBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(max)
+            .ToList();
+    }
+
+    private static (string Field, string Value, int Score)? BestMatch(Resource r, string q) {
+        (string Field, string Value, int Score)? best = null;
+
+        void Consider(string field, string? value, int weight) {
+            if (string.IsNullOrEmpty(value)) return;
+            var score = ScoreField(value, q, weight);
+            if (score <= 0) return;
+            if (best is null || score > best.Value.Score) {
+                best = (field, value, score);
+            }
+        }
+
+        Consider("name", r.Name, _weightName);
+
+        var ip = GetIp(r);
+        Consider("ip", ip, _weightIp);
+
+        if (r.Tags is not null) {
+            foreach (var tag in r.Tags) {
+                Consider("tag", tag, _weightTag);
+            }
+        }
+
+        if (r.Labels is not null) {
+            foreach (KeyValuePair<string, string> kvp in r.Labels) {
+                // Match against the value (label keys are usually category names,
+                // values hold the meaningful data — IPs, hostnames, etc).
+                Consider("label", $"{kvp.Key}: {kvp.Value}", _weightLabel);
+            }
+        }
+
+        return best;
+    }
+
+    private static string? GetIp(Resource r) => r switch {
+        SystemResource s => s.Ip,
+        Service svc => svc.Network?.Ip,
+        _ => null
+    };
+
+    private static int ScoreField(string? value, string lowerQuery, int weight) {
+        if (string.IsNullOrEmpty(value)) return 0;
+
+        var v = value.ToLowerInvariant();
+        if (v == lowerQuery) return weight + 20;
+        if (v.StartsWith(lowerQuery, StringComparison.Ordinal)) return weight + 10;
+        if (v.Contains(lowerQuery, StringComparison.Ordinal)) return weight;
+        return IsSubsequence(lowerQuery, v) ? weight - 10 : 0;
+    }
+
+    private static bool IsSubsequence(string needle, string haystack) {
+        var i = 0;
+        foreach (var c in haystack) {
+            if (i < needle.Length && c == needle[i]) i++;
+            if (i == needle.Length) return true;
+        }
+        return i == needle.Length;
+    }
+}

--- a/Tests.E2e/GlobalSearchTests.cs
+++ b/Tests.E2e/GlobalSearchTests.cs
@@ -82,8 +82,8 @@ public class GlobalSearchTests(
             //       inside the cap given the seeded name prefixes.
             await search.SearchAsync(token);
             await search.AssertResultExistsAsync("service", $"svc-{token}");
-            await search.AssertResultExistsAsync("server",  $"srv-{token}");
-            await search.AssertResultExistsAsync("switch",  $"sw-{token}");
+            await search.AssertResultExistsAsync("server", $"srv-{token}");
+            await search.AssertResultExistsAsync("switch", $"sw-{token}");
 
             // ───── Click navigates to the resource page ─────
             await search.SearchAsync($"svc-{token}");

--- a/Tests.E2e/GlobalSearchTests.cs
+++ b/Tests.E2e/GlobalSearchTests.cs
@@ -12,30 +12,83 @@ public class GlobalSearchTests(
     private readonly ITestOutputHelper _output = output;
 
     [Fact]
-    public async Task User_Can_Search_For_A_Service_And_Navigate_To_It() {
+    public async Task User_Can_Search_For_Resources_Of_Every_Kind_And_Navigate_To_One() {
         (IBrowserContext context, IPage page) = await CreatePageAsync();
-        var serviceName = $"e2e-search-{Guid.NewGuid():N}"[..20];
+
+        // Shared random token in every seeded name so a single fragment hits
+        // every kind, while a kind-prefixed query isolates one.
+        var token = Guid.NewGuid().ToString("N")[..6];
+
+        var seed = new (string Kind, string Name)[] {
+            ("server",      $"srv-{token}"),
+            ("switch",      $"sw-{token}"),
+            ("firewall",    $"fw-{token}"),
+            ("router",      $"rt-{token}"),
+            ("accesspoint", $"ap-{token}"),
+            ("ups",         $"ups-{token}"),
+            ("desktop",     $"dt-{token}"),
+            ("laptop",      $"lt-{token}"),
+            ("system",      $"sys-{token}"),
+            ("service",     $"svc-{token}"),
+        };
 
         try {
-            // Seed: create a service via the existing services list flow
             await page.GotoAsync(_fixture.BaseUrl);
+            await new MainLayoutPom(page).AssertLoadedAsync();
 
-            var layout = new MainLayoutPom(page);
-            await layout.AssertLoadedAsync();
-            await layout.GotoServicesAsync();
+            // ───── Seed: one resource of every kind ─────
+            await page.GotoAsync($"{_fixture.BaseUrl}/servers/list");
+            await new ServersListPom(page).AddServerAsync($"srv-{token}");
 
-            var servicesList = new ServicesListPom(page);
-            await servicesList.AssertLoadedAsync();
-            await servicesList.AddServiceAsync(serviceName);
+            await page.GotoAsync($"{_fixture.BaseUrl}/switches/list");
+            await new SwitchListPom(page).AddSwitchAsync($"sw-{token}");
 
-            // Use global search from the header — partial prefix of the unique name
+            await page.GotoAsync($"{_fixture.BaseUrl}/firewalls/list");
+            await new FirewallsListPom(page).AddFirewallAsync($"fw-{token}");
+
+            await page.GotoAsync($"{_fixture.BaseUrl}/routers/list");
+            await new RouterListPom(page).AddRouterAsync($"rt-{token}");
+
+            await page.GotoAsync($"{_fixture.BaseUrl}/accesspoints/list");
+            await new AccessPointsListPom(page).AddAccessPointAsync($"ap-{token}");
+
+            await page.GotoAsync($"{_fixture.BaseUrl}/ups/list");
+            await new UpsListPom(page).AddUpsAsync($"ups-{token}");
+
+            await page.GotoAsync($"{_fixture.BaseUrl}/desktops/list");
+            await new DesktopsListPom(page).AddDesktopAsync($"dt-{token}");
+
+            await page.GotoAsync($"{_fixture.BaseUrl}/laptops/list");
+            await new LaptopListPom(page).AddLaptopAsync($"lt-{token}");
+
+            await page.GotoAsync($"{_fixture.BaseUrl}/systems/list");
+            await new SystemsListPom(page).AddSystemAsync($"sys-{token}");
+
+            await page.GotoAsync($"{_fixture.BaseUrl}/services/list");
+            await new ServicesListPom(page).AddServiceAsync($"svc-{token}");
+
             var search = new GlobalSearchPom(page);
-            await search.SearchAsync(serviceName[..12]);
-            await search.AssertResultExistsAsync("service", serviceName);
 
-            // Click the result and assert navigation to the service detail page
-            await search.ClickResultAsync("service", serviceName);
-            await page.WaitForURLAsync($"**/resources/services/{serviceName}");
+            // ───── Per-kind search: each unique name surfaces its own kind ─────
+            foreach ((string Kind, string Name) entry in seed) {
+                await search.SearchAsync(entry.Name);
+                await search.AssertResultExistsAsync(entry.Kind, entry.Name);
+            }
+
+            // ───── Cross-kind search: shared token surfaces results from
+            //       multiple kinds in the same dropdown. Top N is capped at 8;
+            //       within an equal-score tier ties break alphabetically by name,
+            //       so the kinds asserted here are those guaranteed to land
+            //       inside the cap given the seeded name prefixes.
+            await search.SearchAsync(token);
+            await search.AssertResultExistsAsync("service", $"svc-{token}");
+            await search.AssertResultExistsAsync("server",  $"srv-{token}");
+            await search.AssertResultExistsAsync("switch",  $"sw-{token}");
+
+            // ───── Click navigates to the resource page ─────
+            await search.SearchAsync($"svc-{token}");
+            await search.ClickResultAsync("service", $"svc-{token}");
+            await page.WaitForURLAsync($"**/resources/services/svc-{token}");
         }
         catch (Exception) {
             _output.WriteLine("TEST FAILED — Capturing diagnostics");

--- a/Tests.E2e/GlobalSearchTests.cs
+++ b/Tests.E2e/GlobalSearchTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Playwright;
+using Tests.E2e.Infra;
+using Tests.E2e.PageObjectModels;
+using Xunit.Abstractions;
+
+namespace Tests.E2e;
+
+public class GlobalSearchTests(
+    PlaywrightFixture fixture,
+    ITestOutputHelper output) : E2ETestBase(fixture, output) {
+    private readonly PlaywrightFixture _fixture = fixture;
+    private readonly ITestOutputHelper _output = output;
+
+    [Fact]
+    public async Task User_Can_Search_For_A_Service_And_Navigate_To_It() {
+        (IBrowserContext context, IPage page) = await CreatePageAsync();
+        var serviceName = $"e2e-search-{Guid.NewGuid():N}"[..20];
+
+        try {
+            // Seed: create a service via the existing services list flow
+            await page.GotoAsync(_fixture.BaseUrl);
+
+            var layout = new MainLayoutPom(page);
+            await layout.AssertLoadedAsync();
+            await layout.GotoServicesAsync();
+
+            var servicesList = new ServicesListPom(page);
+            await servicesList.AssertLoadedAsync();
+            await servicesList.AddServiceAsync(serviceName);
+
+            // Use global search from the header — partial prefix of the unique name
+            var search = new GlobalSearchPom(page);
+            await search.SearchAsync(serviceName[..12]);
+            await search.AssertResultExistsAsync("service", serviceName);
+
+            // Click the result and assert navigation to the service detail page
+            await search.ClickResultAsync("service", serviceName);
+            await page.WaitForURLAsync($"**/resources/services/{serviceName}");
+        }
+        catch (Exception) {
+            _output.WriteLine("TEST FAILED — Capturing diagnostics");
+            _output.WriteLine($"Current URL: {page.Url}");
+
+            var html = await page.ContentAsync();
+            _output.WriteLine("==== DOM SNAPSHOT START ====");
+            _output.WriteLine(html);
+            _output.WriteLine("==== DOM SNAPSHOT END ====");
+
+            throw;
+        }
+        finally {
+            await context.CloseAsync();
+        }
+    }
+}

--- a/Tests.E2e/PageObjectModels/GlobalSearchPom.cs
+++ b/Tests.E2e/PageObjectModels/GlobalSearchPom.cs
@@ -1,0 +1,44 @@
+using Microsoft.Playwright;
+
+namespace Tests.E2e.PageObjectModels;
+
+/// <summary>
+/// POM for the header-level global search component.
+///
+/// Selectors anchor on stable test IDs:
+///   global-search-input             — the textbox
+///   global-search-results           — the dropdown container (visible when query is non-empty)
+///   global-search-no-results        — empty-state inside the dropdown
+///   global-search-result-{kind}-{n} — one row per match
+///   global-search-result-match      — secondary label inside a row, e.g. "via ip: 10.0.0.5"
+/// </summary>
+public class GlobalSearchPom(IPage page) {
+    public ILocator Input => page.GetByTestId("global-search-input");
+    public ILocator Results => page.GetByTestId("global-search-results");
+    public ILocator NoResults => page.GetByTestId("global-search-no-results");
+
+    public ILocator Result(string kind, string name) =>
+        page.GetByTestId($"global-search-result-{kind.ToLowerInvariant()}-{Sanitize(name)}");
+
+    public ILocator ResultMatchLabel(string kind, string name) =>
+        Result(kind, name).GetByTestId("global-search-result-match");
+
+    public async Task SearchAsync(string query) {
+        await Input.FillAsync(query);
+        await Assertions.Expect(Results).ToBeVisibleAsync();
+    }
+
+    public async Task ClearAsync() => await Input.FillAsync("");
+
+    public async Task ClickResultAsync(string kind, string name) =>
+        await Result(kind, name).ClickAsync();
+
+    public async Task AssertResultExistsAsync(string kind, string name) =>
+        await Assertions.Expect(Result(kind, name)).ToBeVisibleAsync();
+
+    public async Task AssertResultDoesNotExistAsync(string kind, string name) =>
+        await Assertions.Expect(Result(kind, name)).Not.ToBeVisibleAsync();
+
+    private static string Sanitize(string value) =>
+        value.Replace(" ", "-").ToLowerInvariant();
+}


### PR DESCRIPTION
  Adds a search palette in the header (right of the rackpeek logo) for     
  jumping                                                                  
  straight to a resource by name, IP, tag, or label — addressing the user  
  request for "intent-based navigation" as the inventory grows.            
                                                                           
  - New `<GlobalSearch>` component in `Shared.Rcl/Components/` wired into  
    `MainLayout` — visible on every page.                                  
  - `GlobalSearchService` ranks resources against the query with weighted  
    field priorities (name 100 > ip 50 > tag 25 > label 10) and match-shape
    modifiers (equality > prefix > substring > subsequence). No external   
    dependencies; ~20 lines of scoring logic.                              
  - Top 8 results render in a dropdown showing `{name} · {kind} · via      
    {matched-field}: {value}`, so the user sees *why* each result appeared.
  - Click navigates to the resource detail page via `NavigationManager`    
    (resolves the URL via the existing `Resource.GetResourceUrl`).         
  - Keyboard: ↑/↓ to highlight, Enter to navigate, Esc to clear.           
  - Clicking outside the input closes the dropdown (`@onfocusout` with a   
    150ms delay so result clicks still register).                          
  - Inventory is re-queried on each keystroke so new/edited/deleted        
    resources show up without a page refresh. The repo's already in-memory,
    so the cost is negligible.                                             
                                                                           
  Searchable kinds: every hardware sub-kind (server, switch, firewall,     
  router, accesspoint, ups, desktop, laptop), system, service.       