### PR TITLE
fix(visualise): cap rendered SVG at natural size instead of upscaling to fill

### DIFF
--- a/Shared.Rcl/wwwroot/js/graph/index.js
+++ b/Shared.Rcl/wwwroot/js/graph/index.js
@@ -135,13 +135,21 @@
 
         const svgEl = stillLive.querySelector("svg");
         if (svgEl) {
-            // Let the SVG fill its container rather than honouring the
-            // intrinsic max-width Mermaid sets, so pan/zoom feels natural.
+            // Render responsively but cap at the diagram's natural size, so a
+            // narrow/tall diagram (e.g. the logical view, which stacks subnet →
+            // host cards vertically) isn't upscaled to fill the pane — that blew
+            // node text and subgraph titles up many times over. Width fills the
+            // container only up to the diagram's natural width (from the
+            // viewBox); a wider-than-pane diagram still scales down to fit.
+            // Height follows the aspect ratio.
+            const viewBox = (svgEl.getAttribute("viewBox") || "").trim().split(/\s+/);
+            const naturalWidth = viewBox.length === 4 ? parseFloat(viewBox[2]) : NaN;
             svgEl.removeAttribute("width");
             svgEl.removeAttribute("height");
-            svgEl.style.maxWidth = "100%";
             svgEl.style.width = "100%";
-            svgEl.style.height = "100%";
+            svgEl.style.height = "auto";
+            svgEl.style.maxWidth = Number.isFinite(naturalWidth) ? `${naturalWidth}px` : "100%";
+            svgEl.style.maxHeight = "100%";
         }
 
         if (result.bindFunctions) result.bindFunctions(stillLive);


### PR DESCRIPTION
## Problem
On the Visualise pages, `rackpeekGraph.render` strips Mermaid's intrinsic sizing and forces the SVG to `width:100%; height:100%`:

```js
svgEl.removeAttribute("width");
svgEl.removeAttribute("height");
svgEl.style.maxWidth = "100%";
svgEl.style.width = "100%";
svgEl.style.height = "100%";
```

For a **narrow, tall** diagram — the **Logical view** stacks subnet → host cards vertically — the SVG's natural width is small (e.g. a `viewBox` width of ~325px). Forcing `width:100%` of a wide content pane (~2390px) **upscales the whole diagram ~7×**: subgraph titles and node text become enormous and the page becomes thousands of px tall to scroll through.

Repro: a logical graph with one or two subnets and a few host cards. The `10.0.0.0/24` / host-card titles render many times larger than intended.

## Fix
Render responsively but **cap `max-width` at the diagram's natural width** (from the `viewBox`), with `height:auto` to preserve aspect ratio:

```js
const viewBox = (svgEl.getAttribute("viewBox") || "").trim().split(/\s+/);
const naturalWidth = viewBox.length === 4 ? parseFloat(viewBox[2]) : NaN;
svgEl.style.width = "100%";
svgEl.style.height = "auto";
svgEl.style.maxWidth = Number.isFinite(naturalWidth) ? `${naturalWidth}px` : "100%";
svgEl.style.maxHeight = "100%";
```

- Narrow diagrams render at their **natural, readable size** (no upscaling).
- Diagrams wider than the pane still **scale down to fit**.
- `Save PNG` / `Save Mermaid` are unaffected (they derive dimensions from the `viewBox`).

## Verification
Tested live against a logical view with two subnets: the SVG went from `2376×6662` (≈7× upscale) to its natural `325×911`, and the whole diagram is now legible without zooming.

Before: giant titles, ~6600px scroll. After: compact, readable cards.